### PR TITLE
document category options

### DIFF
--- a/_guides/arguments.md
+++ b/_guides/arguments.md
@@ -136,6 +136,38 @@ $ typedoc --externalPattern <pattern>
 
 Define a pattern for files that should be considered being external.
 
+### categorizeByGroup
+
+```bash
+$ typedoc --categorizeByGroup=false
+```
+
+This flag categorizes reflections by group (within properties, methods, etc).
+To allow methods and properties of the same category to be grouped together, set this flag to false.
+Defaults to true
+
+### defaultCategory
+
+```bash
+$ typedoc --defaultCategory="Category Name"
+```
+
+Sets the name for the default category (which is used when some elements of the page are categorized).
+Defaults to 'Other'
+
+### categoryOrder
+
+```json
+{
+  "categoryOrder": ["Category Name", "Other Category", "*"]
+}
+```
+
+Array option (available via json configuration) which allows overriding the order categories display in. A string of `*` indicates where categories that are not in the list should appear.
+
+By default, categories are displayed alphabetically. If unknown categories are found, they will be listed at the end by default.
+
+
 ### gaID
 
 ```bash

--- a/_guides/doccomments.md
+++ b/_guides/doccomments.md
@@ -116,8 +116,16 @@ Keeps the subsequent code from being documented.
 function doSomething(target: any, value: number): number;
 ```
 
+### ```@category```
+Allows grouping reflections on a page
 
-
+```
+/**
+ * Regular description
+ *
+ * @category Category Name
+ */
+funtion doSomething() {}
 
 ## Namespaces
 

--- a/_includes/help_output.txt
+++ b/_includes/help_output.txt
@@ -2,6 +2,9 @@ Usage:
  typedoc --mode modules --out path/to/documentation path/to/sourcefiles
 
 TypeDoc options:
+ --categorizeByGroup       Specifies whether categorization will be done at the group level.
+ --categoryOrder           Specifies the order in which categories appear. * indicates the relative order for categories not in the list.
+ --defaultCategory         Specifies the default category for reflections without a category.
  --disableOutputCheck      Should TypeDoc disable the testing and cleaning of the output directory?
  --entryPoint              Specifies the fully qualified name of the root symbol. Defaults to global namespace.
  --exclude                 Define patterns for excluded files when specifying paths.


### PR DESCRIPTION
Adds descriptions of the new `@category` decorator and options.

Related to TypeStrong/typedoc#566 TypeStrong/typedoc#938