### PR TITLE
Fix rendering of "Namespaces" in doccomments

### DIFF
--- a/_guides/doccomments.md
+++ b/_guides/doccomments.md
@@ -129,6 +129,7 @@ Allows grouping reflections on a page
  * @category Category Name
  */
 funtion doSomething() {}
+```
 
 ## Namespaces
 


### PR DESCRIPTION
Hello,

I made a small change because the website currently looks like this:
![grafik](https://user-images.githubusercontent.com/1929063/65429262-29983b00-de16-11e9-8492-ee094cd91244.png)

The ending code fences were missing after the `@category` example.

Cheers,
marc