### PR TITLE
fix: typo @internal hidden by excludeInternal

### DIFF
--- a/guides/doccomments.md
+++ b/guides/doccomments.md
@@ -142,7 +142,7 @@ function doSomething(target: any, value: number): number;
 ### `@internal`
 
 Marks the following code as internal.
-If the `--excludeExternal` option is passed, TypeDoc will not document the given code.
+If the `--excludeInternal` option is passed, TypeDoc will not document the given code.
 
 ```typescript
 /** @internal */


### PR DESCRIPTION
Seems like `--excludeInternal` is the flag that hides `@internal` code, not `--excludeExternal`, per https://typedoc.org/guides/options/#excludeinternal