### PR TITLE
Document Bitbucket source linking and new githubPages options

### DIFF
--- a/guides/options.md
+++ b/guides/options.md
@@ -336,7 +336,7 @@ The available sorting strategies are:
 $ typedoc --gitRevision <revision|branch>
 ```
 
-Use specified revision or branch instead of the last revision for linking to GitHub source files.
+Use specified revision or branch instead of the last revision for linking to GitHub/Bitbucket source files.
 
 ### gitRemote
 
@@ -344,9 +344,19 @@ Use specified revision or branch instead of the last revision for linking to Git
 $ typedoc --gitRemote <remote>
 ```
 
-Use the specified git remote instead of `origin` for linking to GitHub source files.
+Use the specified git remote instead of `origin` for linking to GitHub/Bitbucket source files.
 You can use `git remote` to view a list of valid remotes.
 If you are updating documentation for a forked package, you probably want to pass `--gitRemote upstream`.
+
+### githubPages
+
+```bash
+$ typedoc --githubPages false
+```
+
+When enabled, automatically add a `.nojekyll` file to the output directory to prevent GitHub Pages
+from processing your documentation site using Jekyll. If you have scoped packages, TypeDoc
+generates HTML files that start with `_` which are ignored by Jekyll. Defaults to `true`.
 
 ### gaID
 


### PR DESCRIPTION
See https://github.com/TypeStrong/typedoc/pull/1693 and https://github.com/TypeStrong/typedoc/pull/1695.