### PR TITLE
Fix monospace font

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -110,7 +110,7 @@ body {
 }
 .typography code,
 .typography pre {
-    font-family: "Segoe UI", fixed;
+    font-family: "Segoe UI Mono", monospace;
     padding: 0.2em;
     margin: 0;
     font-size: 85%;


### PR DESCRIPTION
The current font is not monospace and uses "Segoe UI" (which is also not monospace).

This PR replaces `"Segoe UI"` with `"Segoe UI Mono"`, and changes the fallback from `fixed` (which is invalid) to `monospace`.