### PR TITLE
Expand / clarify compilerOptions docs.

### DIFF
--- a/guides/options.md
+++ b/guides/options.md
@@ -112,8 +112,8 @@ TypeDoc provides its default configuration for extension in `typedoc/tsdoc.json`
 
 ### compilerOptions
 
-Used to selectively override compiler options for generating documentation. Values set with this option
-will override options read from `tsconfig.json`.
+Used to selectively override compiler options for generating documentation. TypeDoc parses code using the TypeScript compiler and will therefore behave similarly to tsc. Values set with this option
+will override options read from `tsconfig.json`. See [#1891](https://github.com/TypeStrong/typedoc/pull/1891) for details.
 
 ```json
 {


### PR DESCRIPTION
See https://github.com/TypeStrong/typedoc/issues/2143 for context.  I found it confusing to be setting TypeScript compiler options on a doc generator. Hopefully my edit will make it a little clearer / help people find appropriate context in the context.  Feel free to reject if you're not a fan. No biggie.