### PR TITLE
docs: remove incorrect property from kindsSortOrder

### DIFF
--- a/options/organization.md
+++ b/options/organization.md
@@ -118,7 +118,6 @@ Specifies the relative ordering of reflections if `kind` is specified in the `so
         "Function",
         "Accessor",
         "Method",
-        "ObjectLiteral",
         "Parameter",
         "TypeParameter",
         "TypeLiteral",


### PR DESCRIPTION
ObjectLiteral throws an error in practice