### PR TITLE
Use "node --loader ts-node/esm" instead of "ts-node --esm"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
             - name: Set up Node
               uses: actions/setup-node@v3
               with:
-                  node-version: "18.17"
+                  node-version: "20.12.1"
             - name: Install
               run: npm ci
             - name: Rebuild /api

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "ts-node": "^10.9.1"
   },
   "scripts": {
-    "update-tag-order": "ts-node --esm scripts/update-tag-order.ts",
-    "get-plugins": "ts-node --esm scripts/plugins.ts",
-    "get-changelog": "ts-node --esm scripts/changelog.ts",
+    "update-tag-order": "node --loader ts-node/esm scripts/update-tag-order.ts",
+    "get-plugins": "node --loader ts-node/esm scripts/plugins.ts",
+    "get-changelog": "node --loader ts-node/esm scripts/changelog.ts",
     "prebuild": "npm run get-plugins && npm run get-changelog",
     "build": "npx @11ty/eleventy",
     "serve": "npx @11ty/eleventy --serve",


### PR DESCRIPTION
Since ESM loader hookers now run on a dedicated thread, load the esm module from node directly:

https://github.com/TypeStrong/ts-node/issues/1997#issuecomment-1518740123